### PR TITLE
Add processor configuration for C96 for generic Linux target

### DIFF
--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -130,6 +130,20 @@
   </grid>
 
   <grid name="a%C96">
+    <mach name="linux">
+      <pes pesize="any" compset="ufsatm">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>8</ntasks_atm>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+	</nthrds>
+      </pes>
+    </mach>
+  </grid>
+
+  <grid name="a%C96">
     <mach name="any">
       <pes pesize="any" compset="ufsatm">
         <comment>none</comment>


### PR DESCRIPTION
This PR is required to set the default number of MPI tasks to 8 for running the C96 grid on a generic Linux platform (similar to what is done for macOS). Tested to work on a Amazon instance using Ubuntu 18.04 after following the installation instructions on the NCEPLIBS-external repository.