### PR TITLE
release/public-v1: adjust tasks per node and number of nodes for chgres pre-processing step; return to old version of buildlib used in UFS MR-Weather App release version 1.0

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -891,11 +891,11 @@ def _create_namelist_chgres(case, confdir, config, infile, nmlgen, nmlgen_def, n
     # Check/correct task count used for pre-processing
     mach = case.get_value("MACH") 
     atm_grid = case.get_value("ATM_GRID").replace('r', '')
-    tasks_per_node = 6
-    task_count = {"C96"  : 2*tasks_per_node, # 2 nodes
-                  "C192" : 2*tasks_per_node, # 2 nodes
-                  "C384" : 4*tasks_per_node, # 4 nodes
-                  "C768" : 6*tasks_per_node} # 6 nodes
+    tasks_per_node = 12
+    task_count = {"C96"  : 1*tasks_per_node, # 2 nodes
+                  "C192" : 1*tasks_per_node, # 2 nodes
+                  "C384" : 2*tasks_per_node, # 4 nodes
+                  "C768" : 3*tasks_per_node} # 6 nodes
 
     if atm_grid in task_count.keys():
         case.set_value("tasks_per_node", str(tasks_per_node), subgroup="case.chgres")


### PR DESCRIPTION
### Note: this PR is currently for master, because git log shows that the branch I am working on is master with two commits on top if it
```
commit 0330e9c5ebc0cb40353f65d1097133e8e638bb18 (HEAD -> adjust_chgres_nodes_task_per_node, dom/adjust_chgres_nodes_task_per_node)
Author: Dom Heinzeller <climbfuji@ymail.com>
Date:   Tue Sep 22 06:01:42 2020 -0600

    cime_config/buildnml: adjust number of nodes and tasks per node for chgres pre-processing step

commit 10e9b7b6dac5d4b4dec42913b650f5bfd5a6c880
Author: uturuncoglu <turuncu@ucar.edu>
Date:   Wed Sep 9 21:59:26 2020 -0600

    return old version of buildlib used in UFS MR-Weather App release version 1.0

commit 69b96bea23214146fa80d24852ae7364c2ab3022 (origin/master, origin/HEAD, master)
Author: uturuncoglu <turuncu@ucar.edu>
Date:   Tue Sep 8 11:37:39 2020 -0600

    update test list to include Cheyenne with GNU and Orion
```

The existing branch `release/public-v1` is several commits behind and in my opinion should be replaced with my proposed changes.

For a description of the problem and a summary of how this was solved, see
https://github.com/ufs-community/ufs-mrweather-app/issues/190
https://github.com/ufs-community/ufs-mrweather-app/issues/200
